### PR TITLE
Revert summary redirect

### DIFF
--- a/modules/EnsEMBL/Web/Apache/Handlers.pm
+++ b/modules/EnsEMBL/Web/Apache/Handlers.pm
@@ -1,0 +1,40 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2018] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package EnsEMBL::Web::Apache::Handlers;
+
+use strict;
+use warnings;
+no warnings qw(uninitialized);
+
+use previous qw(get_redirect_uri);
+
+sub get_redirect_uri {
+  my ($r, $uri) = @_;
+  my $undef = PREV::get_redirect_uri($r, $uri);
+
+  if ($uri =~ /Bemisia_tabaci_sweetpotug/) {
+    $uri =~ s/sweetpotug/uganda1/;
+    return $uri;
+  }
+
+  return undef;
+}
+
+1;


### PR DESCRIPTION
In variant table page the redirect from summary page to explore wasn't working. 
Jira ticket: [ENSWEB-6539](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6539)
Jira ticket: [ENSWEB-6502](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6502)

[SandBox](http://wp-np2-1e:8785/Anopheles_gambiae/Gene/Variation_Gene/Table?db=core;g=AGAP029451;r=2R:11467344-11496378;source=VBP0000002;v=tmp_2R_11462677_C_T;vdb=variation;vf=52783028)