### PR TITLE
Call previous plugin's modify_tree method before applying own modifications

### DIFF
--- a/modules/EnsEMBL/Web/Configuration/Gene.pm
+++ b/modules/EnsEMBL/Web/Configuration/Gene.pm
@@ -19,10 +19,14 @@ limitations under the License.
 
 package EnsEMBL::Web::Configuration::Gene;
 
+use previous qw(modify_tree);
 use List::MoreUtils qw(any);
 
 sub modify_tree {
   my $self         = shift;
+
+  $self->PREV::modify_tree(@_);
+
   my $hub          = $self->hub;
   my $species_defs = $hub->species_defs;
   my $species = $hub->species;


### PR DESCRIPTION
Turns out, the left-side navigation tree is already modified in Configuration/Gene.pm module of eg-web-common. In this PR, we are calling parent't method first before applying metazoa-specific changes.

**Sandbox links:**
- Honeybee (has both default and protostomes trees): http://wp-np2-1e.ebi.ac.uk:8440/Apis_mellifera/Gene/Protostomes_Tree?g=LOC726692;r=CM009944.2:6529304-6531367
- Actinia equina (has only the default tree): http://wp-np2-1e.ebi.ac.uk:8440/Actinia_equina_GCA_011057435.1/Gene/Compara_Tree?g=EGACTEQ4350041359;r=WHPX01001324.1:62642-66571;t=EGACTEQ4350041359-RA
- Trichuris muris (has only the protostomes tree): http://wp-np2-1e.ebi.ac.uk:8440/Trichuris_muris_prjeb126/Gene/Protostomes_Tree?g=WBGene00286032;r=TMUE_LG2:6899491-6904247;t=TMUE_2000008757.1