### PR TITLE
New clades to account for inadequatlely assigned "metazoa" species

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -1,6 +1,6 @@
 [general]
 ENSEMBL_BLAST_DATA_PATH = /nfs/ensembl/ensembl-genomes/BLASTDATA/metazoa
-TAXON_ORDER = [Eukaryota Metazoa Diptera Nematoda Hymenoptera Lepidoptera Coleoptera Hemiptera Phthiraptera Isoptera Crustacea Myriapoda Chelicerata Echinodermata Annelida Brachiopoda Mollusca Platyhelminthes Cnidaria Ctenophora Placozoa Porifera Rotifera]
+TAXON_ORDER = [Eukaryota Metazoa Diptera Nematoda Hymenoptera Lepidoptera Coleoptera Hemiptera Phthiraptera Isoptera Crustacea Myriapoda Chelicerata Echinodermata Annelida Brachiopoda Mollusca Platyhelminthes Cnidaria Ctenophora Placozoa Porifera Rotifera Cephalochordata Collembola Acoelomorpha Eutardigrada Acanthocephala Priapulida Hemichordata Orthoptera Thysanoptera Dictyoptera]
 DATA_SOURCE = VectorBase (www.vectorbase.org)
 GENOMIC_UNIT = metazoa
 COMPARA_DB_NAME = Metazoan Compara


### PR DESCRIPTION
Additionally clades for species currently listed on ensembl-metazoa main site as 'metazoa'. This labelling is not very informative and could be improved. 

Changes made related to old JIRA ticket https://www.ebi.ac.uk/panda/jira/browse/EG-3378

# **Species which changes affect:**
Branchiostoma lanceolatum (Amphioxus)	Metazoa	7740 -> Cephalochordata 
Folsomia candida (Springtail, str. VU population)	Metazoa	158441	-> Collembola 
Hofstenia miamia (Panther worm, MS-H3)	Metazoa	442651	-> Acoelomorpha 
Hypsibius exemplaris (Water bear tardigrade, Z151)	Metazoa	2072580	-> Eutardigrada
Orchesella cincta (Springtail)	Metazoa	48709 -> Collembola
Pomphorhynchus laevis (Thorny-headed worm, GPI110)	Metazoa	141832	-> Acanthocephala
Priapulus caudatus (Penis worm)	Metazoa	37621	-> Priapulida
Saccoglossus kowalevskii (Acorn worm)	Metazoa	10224	-> Hemichordata
Schistocerca americana (American grasshopper, TAMUIC-IGC-003095)	Metazoa	7009	-> Orthoptera
Thrips palmi (Melon Thrips, BJ-2018)	Metazoa	161013	-> Thysanoptera
Zootermopsis nevadensis (Nevada dampwood termite)	Metazoa	136037 -> Dictyoptera