### PR TITLE
Added appropriate clades for two new groups introduced with E111

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -1,6 +1,6 @@
 [general]
 ENSEMBL_BLAST_DATA_PATH = /nfs/ensembl/ensembl-genomes/BLASTDATA/metazoa
-TAXON_ORDER = [Nematoda Coleoptera Diptera Hemiptera Hymenoptera Lepidoptera Collembola Dictyoptera Isoptera Orthoptera Phthiraptera Thysanoptera Crustacea Myriapoda Chelicerata Tardigrada Priapulida Acanthocephala Annelida Brachiopoda Mollusca Platyhelminthes Rotifera Echinodermata Cephalochordata Hemichordata Acoelomorpha Cnidaria Ctenophora Porifera Placozoa Metazoa Eukaryota]
+TAXON_ORDER = [Nematoda Coleoptera Diptera Hemiptera Hymenoptera Lepidoptera Collembola Dictyoptera Isoptera Orthoptera Phthiraptera Thysanoptera Trichoptera Crustacea Myriapoda Chelicerata Tardigrada Priapulida Acanthocephala Annelida Brachiopoda Mollusca Nemertea Platyhelminthes Rotifera Echinodermata Cephalochordata Hemichordata Acoelomorpha Cnidaria Ctenophora Placozoa Porifera Metazoa Eukaryota]
 DATA_SOURCE = VectorBase (www.vectorbase.org)
 GENOMIC_UNIT = metazoa
 COMPARA_DB_NAME = Metazoan Compara


### PR DESCRIPTION
**Changes to default ini needed for live site E111/EG58 release:** 

Addition of two new clades related to e111 introduced species belonging to Trichoptera (insect order) and one species of Nemertea (Protostome phylum).

Also slight change in order of lower metazoan clades: porifera <-> placozoa swapped position. 
