### PR TITLE
Add Insects gene tree page for Metazoa

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/InsectsTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/InsectsTree.pm
@@ -1,0 +1,51 @@
+=head1 LICENSE
+
+Copyright [2009-2022] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package EnsEMBL::Web::Component::Gene::InsectsTree;
+
+use strict;
+use warnings;
+
+use base qw (EnsEMBL::Web::Component::Gene::ComparaTree);
+
+sub _init {
+  my ($self) = @_;
+
+  # A horrible hack: it is injecting a clusterset_id parameter into the CGI module,
+  # as if this parameter was part of the url query string.
+  # We need to convince our code to do the same as for the default tree, only for the insects one;
+  # and this, after several less successful attempts, seemed like the easiest way to do so.
+  my $cgi_input = $self->hub->input;
+  $cgi_input->param('clusterset_id', 'insects'); # This is nasty!
+
+  return $self->SUPER::_init(@_);
+}
+
+sub viewconfig {
+  my ($self) = @_;
+  my $viewconfig = $self->hub->get_viewconfig('ComparaTree');
+
+  # Adding this for good measure.
+  # The ComparaTree.pm module in eg-web-common reads clusterset id both from the viewconfig,
+  # and from the genetree object; and gets confused if they don't match.
+  $viewconfig->{'options'}{'clusterset_id'} = 'insects';
+
+  return $viewconfig;
+}
+
+1;

--- a/modules/EnsEMBL/Web/Configuration/Gene.pm
+++ b/modules/EnsEMBL/Web/Configuration/Gene.pm
@@ -22,6 +22,8 @@ package EnsEMBL::Web::Configuration::Gene;
 use previous qw(modify_tree);
 use List::MoreUtils qw(any);
 
+use Data::Dumper;
+
 sub modify_tree {
   my $self         = shift;
 
@@ -37,17 +39,26 @@ sub modify_tree {
   # A species can have one or more of these trees associated with it
   my $clusterset_ids = $hub->species_defs->multi_hash->{'DATABASE_COMPARA'}{'METAZOA_CLUSTERSETS'}{$species_production_name};
 
+  warn "CLUSTERSET IDS";
+  warn Dumper($clusterset_ids);
 
   my $genetree_menu = $self->get_node('Compara_Tree');
 
   $genetree_menu->set('caption', 'Gene tree (Metazoa)');
   $genetree_menu->set('availability', $self->has_default_gene_tree($clusterset_ids));
 
-  $genetree_menu->after($self->create_node('Protostomes_Tree', 'Gene tree (Protostomes)',
+  my $protostomes_node = $self->create_node('Protostomes_Tree', 'Gene tree (Protostomes)',
     [qw( image EnsEMBL::Web::Component::Gene::ProtostomesTree )],
     { 'availability' => $self->has_protostomes_gene_tree($clusterset_ids) }
-  ));
+  );
 
+  my $insects_node = $self->create_node('Insects_Tree', 'Gene tree (Insects)',
+    [qw( image EnsEMBL::Web::Component::Gene::InsectsTree )],
+    { 'availability' => $self->has_insects_gene_tree($clusterset_ids) }
+  );
+
+  $genetree_menu->after($protostomes_node);
+  $protostomes_node -> after($insects_node);
 
   my $compara_strains_menu = $self->get_node('Strain_Compara');
 
@@ -67,6 +78,12 @@ sub has_protostomes_gene_tree {
   my ($self, $clusterset_ids) = @_;
 
   return any { $_ eq "protostomes" } @$clusterset_ids;
+}
+
+sub has_insects_gene_tree {
+  my ($self, $clusterset_ids) = @_;
+
+  return any { $_ eq "insects" } @$clusterset_ids;
 }
 
 1;


### PR DESCRIPTION
## Description
This PR adds the Insects gene tree to Metazoa, the same way we added the Protostomes tree in https://github.com/EnsemblGenomes/eg-web-metazoa/pull/19.

## Jira ticket
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6886

## Sandbox links
- http://wp-np2-1e.ebi.ac.uk:8440/Orchesella_cincta/Gene/Insects_Tree?db=core;g=Ocin01_20226;r=Ocin01_Sc9020:2009-3077;t=ODM59405 — gene in an organism that is only clustered in the Insects tree
- http://wp-np2-1e.ebi.ac.uk:8440/Apis_mellifera/Gene/Insects_Tree?db=core;g=LOC726692;r=CM009944.2:6529304-6531367;t=XM_006563071 — Honeybee, has all three trees