### PR TITLE
Return homology count of zero for non-Compara gene

### DIFF
--- a/modules/EnsEMBL/Web/Query/Availability/Gene.pm
+++ b/modules/EnsEMBL/Web/Query/Availability/Gene.pm
@@ -40,8 +40,6 @@ sub _counts {
   # homologs and orthologs are only calculated against the default clusterset;
   # but metazoa have three clustersets
   for my $clusterset_id (@$clusterset_ids) {
-    warn "CLUSTERSET ID " . $clusterset_id;
-    warn $compara_member->number_of_paralogues($clusterset_id) if defined $compara_member;
 
     if (!$counts->{'orthologs'}) {
       my $orthologs_count = defined $compara_member ? $compara_member->number_of_orthologues($clusterset_id) : 0;

--- a/modules/EnsEMBL/Web/Query/Availability/Gene.pm
+++ b/modules/EnsEMBL/Web/Query/Availability/Gene.pm
@@ -41,15 +41,15 @@ sub _counts {
   # but metazoa have three clustersets
   for my $clusterset_id (@$clusterset_ids) {
     warn "CLUSTERSET ID " . $clusterset_id;
-    warn $compara_member->number_of_paralogues($clusterset_id);
+    warn $compara_member->number_of_paralogues($clusterset_id) if defined $compara_member;
 
     if (!$counts->{'orthologs'}) {
-      my $orthologs_count = $compara_member->number_of_orthologues($clusterset_id);
+      my $orthologs_count = defined $compara_member ? $compara_member->number_of_orthologues($clusterset_id) : 0;
       $counts->{'orthologs'} = $orthologs_count;      
     }
 
     if (!$counts->{'paralogs'}) {
-      my $paralogs_count = $compara_member->number_of_paralogues($clusterset_id);
+      my $paralogs_count = defined $compara_member ? $compara_member->number_of_paralogues($clusterset_id) : 0;
       $counts->{'paralogs'} = $paralogs_count;
     }
   }


### PR DESCRIPTION
This PR contains a small defensive code change to Metazoa gene availability code, to return an orthologue/paralogue count of zero for non-Compara genes.

Functioning example on Compara sandbox: http://wp-np2-25.ebi.ac.uk:5094/Exaiptasia_diaphana_gca001417965v1/Gene/Summary?g=LOC114576745
