### PR TITLE
Add multiple genome alignments overview

### DIFF
--- a/htdocs/info/genome/compara/multiple_genome_alignments.html
+++ b/htdocs/info/genome/compara/multiple_genome_alignments.html
@@ -1,0 +1,28 @@
+<html>
+<head>
+
+  <meta name="navigation" content="Comparative Genomics">
+  <title>Multiple genome alignments</title>
+
+
+</head>
+
+<body>
+
+
+<h1 id="multiplegenomealignments">Multiple genome alignments</h1>
+
+<p>Multiple alignments are calculated between groups of genomes.</p>
+
+<h2 id="alignmentsavailable">Alignments available</h2>
+
+[[SCRIPT::EnsEMBL::Web::Document::HTML::Compara::format_wga_table()]]
+
+<h2 id="alignmentmethods">Alignment methods</h2>
+
+<h3 id="progressivecactus">Progressive Cactus</h3>
+
+<p>Progressive-Cactus is a next-generation aligner that stores whole-genome alignments in a graph structure. Genomes can be added incrementally, which makes it scalable to hundreds of genomes. Further details on these methods can be found in <a href="https://europepmc.org/articles/PMC3166836">Algorithms for genome multiple sequence alignment</a> and <a href="https://europepmc.org/abstract/MED/21385048">Cactus graphs for genome comparisons</a>.</p>
+
+</body>
+</html>


### PR DESCRIPTION
This PR adds a multiple genome alignments page to the Ensembl Metazoa site, including a listing of available multiple genome alignments, as well as a short segment of alignment method documentation for Progressive Cactus.

See example in Metazoa Compara sandbox, configured with `ensembl_compara_metazoa_59_112`: http://wp-np2-25.ebi.ac.uk:5094/info/genome/compara/multiple_genome_alignments.html