### PR TITLE
Add Drosophila pangenome gene tree view

### DIFF
--- a/modules/EnsEMBL/Web/Component/DataExport/Orthologs.pm
+++ b/modules/EnsEMBL/Web/Component/DataExport/Orthologs.pm
@@ -81,6 +81,10 @@ sub get_genetree_fields {
     insects => {
       caption => 'Insects',
       value => 'insects',
+    },
+    pangenome_drosophila => {
+      caption => 'Drosophilidae',
+      value => 'pangenome_drosophila',
     }
   );
 

--- a/modules/EnsEMBL/Web/Component/Gene/DrosophilidaeTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/DrosophilidaeTree.pm
@@ -1,0 +1,48 @@
+=head1 LICENSE
+
+Copyright [2009-2023] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package EnsEMBL::Web::Component::Gene::DrosophilidaeTree;
+
+use strict;
+use warnings;
+
+use base qw (EnsEMBL::Web::Component::Gene::ComparaTree);
+
+sub _init {
+  my ($self) = @_;
+
+  # A horrible hack, but a necessary one.
+  my $cgi_input = $self->hub->input;
+  $cgi_input->param('clusterset_id', 'pangenome_drosophila');
+
+  return $self->SUPER::_init(@_);
+}
+
+sub viewconfig {
+  my ($self) = @_;
+  my $viewconfig = $self->hub->get_viewconfig('ComparaTree');
+
+  # Adding this for good measure.
+  # The ComparaTree.pm module in eg-web-common reads clusterset id both from the viewconfig,
+  # and from the genetree object; and gets confused if they don't match.
+  $viewconfig->{'options'}{'clusterset_id'} = 'pangenome_drosophila';
+
+  return $viewconfig;
+}
+
+1;

--- a/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -52,7 +52,7 @@ sub _configure_new_gene_trees {
     $sth->execute;
 
     # get all Compara clusterset ids to which a species may belong
-    # (possible values for Metazoa: "default", "protostomes", "insects")
+    # (possible values for Metazoa: "default", "protostomes", "insects", "pangenome_drosophila")
     my $clusterset_ids = $sth->fetchall_arrayref();
 
     foreach my $row (@{$clusterset_ids}) {

--- a/modules/EnsEMBL/Web/Configuration/Gene.pm
+++ b/modules/EnsEMBL/Web/Configuration/Gene.pm
@@ -52,8 +52,14 @@ sub modify_tree {
     { 'availability' => $self->has_insects_gene_tree($clusterset_ids) }
   );
 
+  my $drosophilidae_node = $self->create_node('Drosophilidae_Tree', 'Gene tree (Drosophilidae)',
+    [qw( image EnsEMBL::Web::Component::Gene::DrosophilidaeTree )],
+    { 'availability' => $self->has_drosophilidae_gene_tree($clusterset_ids) }
+  );
+
   $genetree_menu->after($protostomes_node);
   $protostomes_node -> after($insects_node);
+  $insects_node -> after($drosophilidae_node);
 
   my $compara_strains_menu = $self->get_node('Strain_Compara');
 
@@ -79,6 +85,12 @@ sub has_insects_gene_tree {
   my ($self, $clusterset_ids) = @_;
 
   return any { $_ eq "insects" } @$clusterset_ids;
+}
+
+sub has_drosophilidae_gene_tree {
+  my ($self, $clusterset_ids) = @_;
+
+  return any { $_ eq "pangenome_drosophila" } @$clusterset_ids;
 }
 
 1;

--- a/modules/EnsEMBL/Web/Query/Availability/Gene.pm
+++ b/modules/EnsEMBL/Web/Query/Availability/Gene.pm
@@ -32,7 +32,7 @@ sub _counts {
   my $species_defs = $hub->species_defs;
   my $species_production_name = $species_defs->SPECIES_PRODUCTION_NAME;
 
-  # Possible gene cluster set ids for metazoa: "default", "protostomes", "insects".
+  # Possible gene cluster set ids for metazoa: "default", "protostomes", "insects", "pangenome_drosophila".
   # A species can have one or more of these trees associated with it
   my $clusterset_ids = $hub->species_defs->multi_hash->{'DATABASE_COMPARA'}{'METAZOA_CLUSTERSETS'}{$species_production_name};
 


### PR DESCRIPTION
This PR adds a gene-tree view for the Drosophila pangenome being introduced in Ensembl 112.

Example tree in Compara sandbox: http://wp-np2-25.ebi.ac.uk:5094/Drosophila_melanogaster/Gene/Drosophilidae_Tree?db=core;g=FBgn0014857