### PR TITLE
Set availability of Metazoa gene trees per gene

### DIFF
--- a/modules/EnsEMBL/Web/Configuration/Gene.pm
+++ b/modules/EnsEMBL/Web/Configuration/Gene.pm
@@ -40,16 +40,16 @@ sub modify_tree {
   my $genetree_menu = $self->get_node('Compara_Tree');
 
   $genetree_menu->set('caption', 'Gene tree (Metazoa)');
-  $genetree_menu->set('availability', $self->has_default_gene_tree($clusterset_ids));
+  $genetree_menu->set('availability', 'gene database:compara core has_gene_tree');
 
   my $protostomes_node = $self->create_node('Protostomes_Tree', 'Gene tree (Protostomes)',
     [qw( image EnsEMBL::Web::Component::Gene::ProtostomesTree )],
-    { 'availability' => $self->has_protostomes_gene_tree($clusterset_ids) }
+    { 'availability' => 'gene database:compara core has_gene_tree_protostomes' }
   );
 
   my $insects_node = $self->create_node('Insects_Tree', 'Gene tree (Insects)',
     [qw( image EnsEMBL::Web::Component::Gene::InsectsTree )],
-    { 'availability' => $self->has_insects_gene_tree($clusterset_ids) }
+    { 'availability' => 'gene database:compara core has_gene_tree_insects' }
   );
 
   $genetree_menu->after($protostomes_node);
@@ -61,24 +61,6 @@ sub modify_tree {
     $compara_strains_menu->remove();
   }
 
-}
-
-sub has_default_gene_tree {
-  my ($self, $clusterset_ids) = @_;
-
-  return any { $_ eq "default" } @$clusterset_ids;
-}
-
-sub has_protostomes_gene_tree {
-  my ($self, $clusterset_ids) = @_;
-
-  return any { $_ eq "protostomes" } @$clusterset_ids;
-}
-
-sub has_insects_gene_tree {
-  my ($self, $clusterset_ids) = @_;
-
-  return any { $_ eq "insects" } @$clusterset_ids;
 }
 
 1;

--- a/modules/EnsEMBL/Web/Query/Availability/Gene.pm
+++ b/modules/EnsEMBL/Web/Query/Availability/Gene.pm
@@ -19,7 +19,7 @@ limitations under the License.
 
 package EnsEMBL::Web::Query::Availability::Gene;
 
-use previous qw(_counts);
+use previous qw(_counts get);
 
 sub _counts {
   my $self = shift;
@@ -53,6 +53,20 @@ sub _counts {
   }
 
   return $counts;
+}
+
+sub get {
+
+  my ($self, $args) = @_;
+
+  my ($out) = @{$self->PREV::get($args)};
+
+  my $member = $self->compara_member($args);
+
+  $out->{'has_gene_tree_protostomes'} = $member ? $member->has_GeneTree('protostomes') : 0;
+  $out->{'has_gene_tree_insects'} = $member ? $member->has_GeneTree('insects') : 0;
+
+  return [$out];
 }
 
 1;


### PR DESCRIPTION
## Description

Set availability of Metazoa gene trees per gene member rather than per genome.

## Views affected

This PR changes how gene-tree availability is determined for Metazoa genes, so that a gene-tree menu item has an active link only if that gene member is part of a gene tree in the given collection (e.g. Metazoa, Protostomes, Insects). It would also fix [ENSWEB-6876](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6876).

See the table for some examples of _Apis mellifera_ genes that are present in at least one Metazoa gene-tree collection, but not all of them.

| gene_stable_id | metazoa | protostomes | insects | links |
|----------------|---------|-------------|---------|-------|
| GeneID_406134  | yes     | no          | yes     | [sandbox](http://wp-np2-25.ebi.ac.uk:5094/Apis_mellifera/Gene/Summary?db=core;g=GeneID_406134) / [staging](https://rc-metazoa.ensembl.org/Apis_mellifera/Gene/Summary?g=GeneID_406134)
| LOC100576473   | yes     | no          | no     | [sandbox](http://wp-np2-25.ebi.ac.uk:5094/Apis_mellifera/Gene/Summary?db=core;g=LOC100576473) / [staging](https://rc-metazoa.ensembl.org/Apis_mellifera/Gene/Summary?g=LOC100576473)
| GeneID_807694  | no      | no          | yes     | [sandbox](http://wp-np2-25.ebi.ac.uk:5094/Apis_mellifera/Gene/Summary?db=core;g=GeneID_807694) / [staging](https://rc-metazoa.ensembl.org/Apis_mellifera/Gene/Summary?g=GeneID_807694)


## Possible complications

No complications expected. This change should only affect Metazoa gene-tree availability.

## Merge conflicts

No merge conflicts detected.

## Related JIRA Issues (EBI developers only)

- [ENSWEB-6876](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6876)

