### PR TITLE
Filter out clustersets for which gene lacks orthologs

### DIFF
--- a/modules/EnsEMBL/Web/Component/DataExport/Orthologs.pm
+++ b/modules/EnsEMBL/Web/Component/DataExport/Orthologs.pm
@@ -61,6 +61,11 @@ sub get_clusterset_ids {
 
   my $clusterset_ids = $hub->species_defs->multi_hash->{'DATABASE_COMPARA'}{'METAZOA_CLUSTERSETS'}{$species_production_name};
 
+  # If possible, we should filter out clustersets for which this gene lacks orthologs.
+  if ($hub->param('g')) {
+    $clusterset_ids = [grep { $hub->core_object('gene')->availability->{"has_orthologs_${_}"} } @$clusterset_ids];
+  }
+
   return $clusterset_ids;
 }
 

--- a/modules/EnsEMBL/Web/Query/Availability/Gene.pm
+++ b/modules/EnsEMBL/Web/Query/Availability/Gene.pm
@@ -63,6 +63,10 @@ sub get {
 
   my $member = $self->compara_member($args);
 
+  $out->{'has_orthologs_default'} = $member ? $member->number_of_orthologues('default') : 0;
+  $out->{'has_orthologs_protostomes'} = $member ? $member->number_of_orthologues('protostomes') : 0;
+  $out->{'has_orthologs_insects'} = $member ? $member->number_of_orthologues('insects') : 0;
+
   $out->{'has_gene_tree_protostomes'} = $member ? $member->has_GeneTree('protostomes') : 0;
   $out->{'has_gene_tree_insects'} = $member ? $member->has_GeneTree('insects') : 0;
 


### PR DESCRIPTION
This PR builds on the gene-tree selector added to the orthologue download modal window in [eg-web-metazoa PR #27](https://github.com/EnsemblGenomes/eg-web-metazoa/pull/27), by filtering out the available gene-tree options if there are no orthologues from that tree for the given gene.

This is analogous to what was done with gene-tree availability in [eg-web-metazoa PR #30](https://github.com/EnsemblGenomes/eg-web-metazoa/pull/30), with a subtle difference: a gene can be in a gene tree but lack orthologues (e.g. GeneID_406134 in the Metazoa tree).

Here are some examples of _Apis mellifera_ genes that have orthologues in at least one Metazoa gene-tree collection, but not all of them.

| gene_stable_id | metazoa | protostomes | insects | links |
|----------------|---------|-------------|---------|-------|
| GeneID_406134  | yes     | no          | yes     | [sandbox](http://wp-np2-25.ebi.ac.uk:5094/Apis_mellifera/Gene/Summary?db=core;g=GeneID_406134) / [RC site](https://rc-metazoa.ensembl.org/Apis_mellifera/Gene/Summary?g=GeneID_406134)
| LOC100576473   | yes     | no          | no     | [sandbox](http://wp-np2-25.ebi.ac.uk:5094/Apis_mellifera/Gene/Summary?db=core;g=LOC100576473) / [RC site](https://rc-metazoa.ensembl.org/Apis_mellifera/Gene/Summary?g=LOC100576473)
| GeneID_807694  | no      | no          | yes     | [sandbox](http://wp-np2-25.ebi.ac.uk:5094/Apis_mellifera/Gene/Summary?db=core;g=GeneID_807694) / [RC site](https://rc-metazoa.ensembl.org/Apis_mellifera/Gene/Summary?g=GeneID_807694)

Note that the Metazoa Compara sandbox link currently also demos the changes in PR #33 in addition to the changes in this PR.