### PR TITLE
Show Drosophila pangenome menu item only if relevant

### DIFF
--- a/modules/EnsEMBL/Web/Configuration/Gene.pm
+++ b/modules/EnsEMBL/Web/Configuration/Gene.pm
@@ -59,7 +59,10 @@ sub modify_tree {
 
   my $drosophilidae_node = $self->create_node('Drosophilidae_Tree', 'Gene tree (Drosophilidae)',
     [qw( image EnsEMBL::Web::Component::Gene::DrosophilidaeTree )],
-    { 'availability' => 'gene database:compara core has_gene_tree_pangenome_drosophila' }
+    {
+      'availability'  => 'gene database:compara core has_gene_tree_pangenome_drosophila',
+      'no_menu_entry' => none { $_ eq 'pangenome_drosophila' } @$clusterset_ids
+    }
   );
   push(@genetree_menu_nodes, $drosophilidae_node);
 

--- a/modules/EnsEMBL/Web/Configuration/Gene.pm
+++ b/modules/EnsEMBL/Web/Configuration/Gene.pm
@@ -20,7 +20,7 @@ limitations under the License.
 package EnsEMBL::Web::Configuration::Gene;
 
 use previous qw(modify_tree);
-use List::MoreUtils qw(any);
+use List::MoreUtils qw(none);
 
 sub modify_tree {
   my $self         = shift;
@@ -37,29 +37,35 @@ sub modify_tree {
   # A species can have one or more of these trees associated with it
   my $clusterset_ids = $hub->species_defs->multi_hash->{'DATABASE_COMPARA'}{'METAZOA_CLUSTERSETS'}{$species_production_name};
 
+  my @genetree_menu_nodes;
+
   my $genetree_menu = $self->get_node('Compara_Tree');
 
   $genetree_menu->set('caption', 'Gene tree (Metazoa)');
   $genetree_menu->set('availability', 'gene database:compara core has_gene_tree');
+  push(@genetree_menu_nodes, $genetree_menu);
 
   my $protostomes_node = $self->create_node('Protostomes_Tree', 'Gene tree (Protostomes)',
     [qw( image EnsEMBL::Web::Component::Gene::ProtostomesTree )],
     { 'availability' => 'gene database:compara core has_gene_tree_protostomes' }
   );
+  push(@genetree_menu_nodes, $protostomes_node);
 
   my $insects_node = $self->create_node('Insects_Tree', 'Gene tree (Insects)',
     [qw( image EnsEMBL::Web::Component::Gene::InsectsTree )],
     { 'availability' => 'gene database:compara core has_gene_tree_insects' }
   );
+  push(@genetree_menu_nodes, $insects_node);
 
   my $drosophilidae_node = $self->create_node('Drosophilidae_Tree', 'Gene tree (Drosophilidae)',
     [qw( image EnsEMBL::Web::Component::Gene::DrosophilidaeTree )],
-    { 'availability' => 'gene database:compara core has_gene_tree_drosophila' }
+    { 'availability' => 'gene database:compara core has_gene_tree_pangenome_drosophila' }
   );
+  push(@genetree_menu_nodes, $drosophilidae_node);
 
-  $genetree_menu->after($protostomes_node);
-  $protostomes_node -> after($insects_node);
-  $insects_node -> after($drosophilidae_node);
+  foreach my $i (0 .. ($#genetree_menu_nodes - 1)) {
+    $genetree_menu_nodes[$i]->after($genetree_menu_nodes[$i+1]);
+  }
 
   my $compara_strains_menu = $self->get_node('Strain_Compara');
 

--- a/modules/EnsEMBL/Web/Query/Availability/Gene.pm
+++ b/modules/EnsEMBL/Web/Query/Availability/Gene.pm
@@ -63,13 +63,19 @@ sub get {
 
   my $member = $self->compara_member($args);
 
-  $out->{'has_orthologs_default'} = $member ? $member->number_of_orthologues('default') : 0;
-  $out->{'has_orthologs_protostomes'} = $member ? $member->number_of_orthologues('protostomes') : 0;
-  $out->{'has_orthologs_insects'} = $member ? $member->number_of_orthologues('insects') : 0;
+  my $hub = $self->context;
+  my $species_defs = $hub->species_defs;
+  my $species_production_name = $species_defs->SPECIES_PRODUCTION_NAME;
+  my $clusterset_ids = $hub->species_defs->multi_hash->{'DATABASE_COMPARA'}{'METAZOA_CLUSTERSETS'}{$species_production_name};
 
-  $out->{'has_gene_tree_protostomes'} = $member ? $member->has_GeneTree('protostomes') : 0;
-  $out->{'has_gene_tree_insects'} = $member ? $member->has_GeneTree('insects') : 0;
-  $out->{'has_gene_tree_drosophila'} = $member ? $member->has_GeneTree('pangenome_drosophila') : 0;
+  foreach my $clusterset_id (@$clusterset_ids) {
+    $out->{"has_orthologs_${clusterset_id}"} = $member ? $member->number_of_orthologues($clusterset_id) : 0;
+
+    # We can use the 'has_gene_tree' tag for the default collection.
+    if ($clusterset_id ne 'default') {
+      $out->{"has_gene_tree_${clusterset_id}"} = $member ? $member->has_GeneTree($clusterset_id) : 0;
+    }
+  }
 
   return [$out];
 }


### PR DESCRIPTION
This PR updates the gene config so that a Drosophila pangenome gene-tree menu item is visible only for genomes which are in the Drosophila pangenome.

Examples of how this looks can be accessed via the Metazoa Compara sandbox links in the following table:

| Species                 | Gene with Drosophila pangenome gene tree | Gene without Drosophila pangenome gene tree |
|-------------------------|------------------------------------------|---------------------------------------------|
| Drosophila melanogaster | [FBgn0014857](http://wp-np2-25.ebi.ac.uk:5094/Drosophila_melanogaster/Gene/Drosophilidae_Tree?collapse=none;db=core;g=FBgn0014857) | [FBgn0031178](http://wp-np2-25.ebi.ac.uk:5094/Drosophila_melanogaster/Gene/Summary?db=core;g=FBgn0031178)
| Drosophila elegans      | [LOC108150740](http://wp-np2-25.ebi.ac.uk:5094/Drosophila_elegans_gca000224195v2rs/Gene/Summary?g=LOC108150740)                    | [LOC108150739](http://wp-np2-25.ebi.ac.uk:5094/Drosophila_elegans_gca000224195v2rs/Gene/Summary?g=LOC108150739)
| Caenorhabditis elegans  | NA                                                                                                                                 | [WBGene00004893](http://wp-np2-25.ebi.ac.uk:5094/Caenorhabditis_elegans/Gene/Summary?g=WBGene00004893)

Note that this PR was initially a draft incorporating changes from [eg-web-metazoa PR #32](https://github.com/EnsemblGenomes/eg-web-metazoa/pull/32).