### PR TITLE
Create ViewConfig modules for Metazoa collections

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/DrosophilidaeTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/DrosophilidaeTree.pm
@@ -33,16 +33,4 @@ sub _init {
   return $self->SUPER::_init(@_);
 }
 
-sub viewconfig {
-  my ($self) = @_;
-  my $viewconfig = $self->hub->get_viewconfig('ComparaTree');
-
-  # Adding this for good measure.
-  # The ComparaTree.pm module in eg-web-common reads clusterset id both from the viewconfig,
-  # and from the genetree object; and gets confused if they don't match.
-  $viewconfig->{'options'}{'clusterset_id'} = 'pangenome_drosophila';
-
-  return $viewconfig;
-}
-
 1;

--- a/modules/EnsEMBL/Web/Component/Gene/InsectsTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/InsectsTree.pm
@@ -36,16 +36,4 @@ sub _init {
   return $self->SUPER::_init(@_);
 }
 
-sub viewconfig {
-  my ($self) = @_;
-  my $viewconfig = $self->hub->get_viewconfig('ComparaTree');
-
-  # Adding this for good measure.
-  # The ComparaTree.pm module in eg-web-common reads clusterset id both from the viewconfig,
-  # and from the genetree object; and gets confused if they don't match.
-  $viewconfig->{'options'}{'clusterset_id'} = 'insects';
-
-  return $viewconfig;
-}
-
 1;

--- a/modules/EnsEMBL/Web/Component/Gene/ProtostomesTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ProtostomesTree.pm
@@ -36,16 +36,4 @@ sub _init {
   return $self->SUPER::_init(@_);
 }
 
-sub viewconfig {
-  my ($self) = @_;
-  my $viewconfig = $self->hub->get_viewconfig('ComparaTree');
-
-  # Adding this for good measure.
-  # The ComparaTree.pm module in eg-web-common reads clusterset id both from the viewconfig,
-  # and from the genetree object; and gets confused if they don't match.
-  $viewconfig->{'options'}{'clusterset_id'} = 'protostomes';
-
-  return $viewconfig;
-}
-
 1;

--- a/modules/EnsEMBL/Web/ViewConfig/Gene/DrosophilidaeTree.pm
+++ b/modules/EnsEMBL/Web/ViewConfig/Gene/DrosophilidaeTree.pm
@@ -1,0 +1,37 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2024] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package EnsEMBL::Web::ViewConfig::Gene::DrosophilidaeTree;
+
+use strict;
+use warnings;
+
+use parent qw(EnsEMBL::Web::ViewConfig::Gene::ComparaTree);
+
+
+sub init_cacheable {
+  ## @override
+  my $self = shift;
+  $self->SUPER::init_cacheable(@_);
+  # The ComparaTree.pm module in eg-web-common reads clusterset id both from the viewconfig,
+  # and from the genetree object; and gets confused if they don't match.
+  $self->set_default_options({'clusterset_id' => 'pangenome_drosophila'});
+}
+
+1;

--- a/modules/EnsEMBL/Web/ViewConfig/Gene/InsectsTree.pm
+++ b/modules/EnsEMBL/Web/ViewConfig/Gene/InsectsTree.pm
@@ -1,0 +1,37 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2024] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package EnsEMBL::Web::ViewConfig::Gene::InsectsTree;
+
+use strict;
+use warnings;
+
+use parent qw(EnsEMBL::Web::ViewConfig::Gene::ComparaTree);
+
+
+sub init_cacheable {
+  ## @override
+  my $self = shift;
+  $self->SUPER::init_cacheable(@_);
+  # The ComparaTree.pm module in eg-web-common reads clusterset id both from the viewconfig,
+  # and from the genetree object; and gets confused if they don't match.
+  $self->set_default_options({'clusterset_id' => 'insects'});
+}
+
+1;

--- a/modules/EnsEMBL/Web/ViewConfig/Gene/ProtostomesTree.pm
+++ b/modules/EnsEMBL/Web/ViewConfig/Gene/ProtostomesTree.pm
@@ -1,0 +1,37 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2024] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package EnsEMBL::Web::ViewConfig::Gene::ProtostomesTree;
+
+use strict;
+use warnings;
+
+use parent qw(EnsEMBL::Web::ViewConfig::Gene::ComparaTree);
+
+
+sub init_cacheable {
+  ## @override
+  my $self = shift;
+  $self->SUPER::init_cacheable(@_);
+  # The ComparaTree.pm module in eg-web-common reads clusterset id both from the viewconfig,
+  # and from the genetree object; and gets confused if they don't match.
+  $self->set_default_options({'clusterset_id' => 'protostomes'});
+}
+
+1;


### PR DESCRIPTION
This PR creates dedicated a ViewConfig module for each of the non-default Metazoa protein-tree collections, circumventing an issue with gene-tree export in the Ensembl Metazoa site ([ENSWEB-6875](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6875)).

Examples of Metazoa gene-tree views that have export functionality following these changes:
- [D. melanogaster His3.3A Protostomes tree](http://wp-np2-25.ebi.ac.uk:5094/Drosophila_melanogaster/Gene/Protostomes_Tree?db=core;g=FBgn0014857)
- [D. melanogaster His3.3A Insects tree](http://wp-np2-25.ebi.ac.uk:5094/Drosophila_melanogaster/Gene/Insects_Tree?db=core;g=FBgn0014857)
- [D. melanogaster His3.3A Drosophila pangenome](http://wp-np2-25.ebi.ac.uk:5094/Drosophila_melanogaster/Gene/Drosophilidae_Tree?db=core;g=FBgn0014857)