### PR TITLE
Skip Metazoa gene-tree field for Pan orthologue download

### DIFF
--- a/modules/EnsEMBL/Web/Component/DataExport/Orthologs.pm
+++ b/modules/EnsEMBL/Web/Component/DataExport/Orthologs.pm
@@ -30,6 +30,10 @@ sub prepare_form {
 
   my $form = $self->PREV::prepare_form(@_);
 
+  # If this is Pan-taxonomic Compara, our work here is done.
+  my $cdb = $self->hub->param('cdb') || 'compara';
+  return $form if $cdb eq 'compara_pan_ensembl';
+
   my $form_node = $form->get_elements_by_tag_name('form')->[0];
   my $genetree_fieldset = $form_node->add_fieldset();
   my $genetree_fields = $self->get_genetree_fields();


### PR DESCRIPTION
The creation of a gene-tree radio button field in the Metazoa orthologue download modal window is unnecessary in the case of Pan Compara, so this PR skips it.

Click on the "Download orthologues" button in each example to see the effect of the change in this PR. The Pan Compara orthologue download modal window includes the gene-tree radio buttons in the Metazoa live site, but not in the Metazoa Compara sandbox.

- Example in Compara sandbox: http://wp-np2-25.ebi.ac.uk:5094/Drosophila_melanogaster/Gene/Compara_Ortholog/pan_compara?g=FBgn0014857
- Example in Metazoa live site: https://metazoa.ensembl.org/Drosophila_melanogaster/Gene/Compara_Ortholog/pan_compara?g=FBgn0014857






