### PR TITLE
Centralise Metazoa gene-tree constants

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
@@ -21,28 +21,7 @@ package EnsEMBL::Web::Component::Gene::ComparaOrthologs;
 use strict;
 use warnings;
 
-our $GENE_TREE_CONSTANTS = {
-  default => {
-    name => 'Metazoa',
-    component => 'ComparaTree',
-    url_part => 'Compara_Tree'
-  },
-  protostomes => {
-    name => 'Protostomes',
-    component => 'ProtostomesTree',
-    url_part => 'Protostomes_Tree'
-  },
-  insects => {
-    name => 'Insects',
-    component => 'InsectsTree',
-    url_part => 'Insects_Tree'
-  },
-  pangenome_drosophila => {
-    name => 'Drosophilidae',
-    component => 'DrosophilidaeTree',
-    url_part => 'Drosophilidae_Tree'
-  }
-};
+use EnsEMBL::Web::Constants;
 
 sub create_gene_tree_links {
   my $self = shift;
@@ -66,10 +45,10 @@ sub create_gene_tree_links {
 
   foreach my $clusterset_ancestor_pair (@clusterset_ancestor_pairs) {
     my ($clusterset_id, $anc_node_id) = @$clusterset_ancestor_pair;
-    my $gene_tree_constants = $self->get_gene_tree_constants_for_clusterset($clusterset_id);
+    my $gene_tree_constants = EnsEMBL::Web::Constants::GENE_TREE_CONSTANTS($cdb, undef, $clusterset_id);
     my $gene_tree_name = $gene_tree_constants->{name};
     my $link_text = $is_single_clusterset ? 'View Gene Tree' : "View $gene_tree_name Gene Tree";
-    my $url_part = $is_pan ? 'PanComparaTree' : $gene_tree_constants->{url_part};
+    my $url_part = $gene_tree_constants->{action};
 
     my $tree_url = $hub->url({
       type   => 'Gene',
@@ -85,7 +64,7 @@ sub create_gene_tree_links {
     push(@link_str_parts, $link_str);
   }
 
-  my $links_str = join('', @link_str_parts);
+  my $links_str = join(' ', @link_str_parts);
 
   return $links_str;
 }
@@ -99,13 +78,6 @@ sub fetch_anc_node_ids {
   my $gene_tree_adaptor = $member->adaptor->db->get_GeneTreeAdaptor;
 
   return $gene_tree_adaptor->_fetch_all_ref_lca_node_ids_by_Member($member);
-}
-
-sub get_gene_tree_constants_for_clusterset {
-  my $self = shift;
-  my $clusterset_id = shift;
-
-  return $GENE_TREE_CONSTANTS->{$clusterset_id};
 }
 
 

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
@@ -24,18 +24,22 @@ use warnings;
 our $GENE_TREE_CONSTANTS = {
   default => {
     name => 'Metazoa',
+    component => 'ComparaTree',
     url_part => 'Compara_Tree'
   },
   protostomes => {
     name => 'Protostomes',
+    component => 'ProtostomesTree',
     url_part => 'Protostomes_Tree'
   },
   insects => {
     name => 'Insects',
+    component => 'InsectsTree',
     url_part => 'Insects_Tree'
   },
   pangenome_drosophila => {
     name => 'Drosophilidae',
+    component => 'DrosophilidaeTree',
     url_part => 'Drosophilidae_Tree'
   }
 };

--- a/modules/EnsEMBL/Web/Constants.pm
+++ b/modules/EnsEMBL/Web/Constants.pm
@@ -1,0 +1,68 @@
+=head1 LICENSE
+
+Copyright [2009-2025] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package EnsEMBL::Web::Constants;
+
+use strict;
+use warnings;
+
+
+sub GENE_TREE_CONSTANTS {
+### Metazoa Compara lookup for various gene-tree views
+  my ($cdb, $strain, $clusterset_id) = @_;
+
+  my $GENE_TREE_CONSTANTS = {
+    compara_pan_ensembl => {
+      name => 'Pan-taxonomic Compara',
+      action => 'PanComparaTree',
+      component => 'PanComparaTree',
+    },
+    default => {
+      name => 'Metazoa',
+      component => 'ComparaTree',
+      action => 'Compara_Tree',
+    },
+    protostomes => {
+      name => 'Protostomes',
+      component => 'ProtostomesTree',
+      action => 'Protostomes_Tree',
+    },
+    insects => {
+      name => 'Insects',
+      component => 'InsectsTree',
+      action => 'Insects_Tree',
+    },
+    pangenome_drosophila => {
+      name => 'Drosophilidae',
+      component => 'DrosophilidaeTree',
+      action => 'Drosophilidae_Tree',
+    },
+  };
+
+  my $gene_tree_view_key;
+  if ($cdb eq 'compara_pan_ensembl') {
+    $gene_tree_view_key = 'compara_pan_ensembl';
+  } else {
+    $gene_tree_view_key = $clusterset_id // 'default';
+  }
+
+  return $GENE_TREE_CONSTANTS->{$gene_tree_view_key};
+}
+
+
+1;


### PR DESCRIPTION
This PR would:
- replace the `$GENE_TREE_CONSTANTS` variable and `get_gene_tree_constants_for_clusterset` method in `EnsEMBL::Web::Component::Gene::ComparaOrthologs` with a centralised `GENE_TREE_CONSTANTS` function in the `EnsEMBL::Web::Constants` module;
- use the centralised `GENE_TREE_CONSTANTS` function to get the name and URL part of Metazoa gene-tree collections; and
- insert a space between orthologue `@link_str_parts` when joining them, to make orthologue tables easier to parse.

In conjunction with [ensembl-webcode PR 1074](https://github.com/Ensembl/ensembl-webcode/pull/1074), this would facilitate export of subtree data for gene trees in Pan-taxonomic Compara, Protostomes, Insects and the Drosophila pangenome.