### PR TITLE
Add Metazoa implementation of SpeciesDefs::_extract_identifying_prefix

### DIFF
--- a/modules/EnsEMBL/Web/SpeciesDefs.pm
+++ b/modules/EnsEMBL/Web/SpeciesDefs.pm
@@ -1,0 +1,37 @@
+=head1 LICENSE
+
+Copyright [2009-2025] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package EnsEMBL::Web::SpeciesDefs;
+
+use strict;
+use warnings;
+
+
+sub _extract_identifying_prefix {
+  # Takes a label and extracts the portion of that label before the first opening parenthesis.
+  # As of Ensembl Metazoa 115, this pulls out the scientific name, which uniquely identifies
+  # most genomes in Metazoa Compara, and all of the genomes that are in a genomic alignment.
+  my ($self, $label) = @_;
+  if ($label =~ /(?<prefix>.+?)(?: - \(|\()/) {
+    $label = $+{'prefix'};
+  }
+  return $label;
+}
+
+
+1;


### PR DESCRIPTION
For ease of use of Ensembl NV sites, the names of genomes in comparative region-in-detail tracks and image alignment views are abbreviated.

As Ensembl Metazoa naming conventions have changed in recent years, the method used to abbreviate genome names (`SpeciesDefs::abbreviated_species_label`) has not kept pace.

This can be seen by comparing the [nematode Cactus alignment in EG45](https://sep2019-metazoa.ensembl.org/Caenorhabditis_elegans/Location/Compara_Alignments/Image?r=X:937766-957832;align=9483;db=core) with [the same alignment in EG59](https://may2024-metazoa.ensembl.org/Caenorhabditis_elegans/Location/Compara_Alignments/Image?r=X:937766-957832;align=9483;db=core). While in the earlier archive the abbreviated names are recognisable as binomial species names, in the more recent alignment view the abbreviated name is dominated by the parenthesised part of the genome display name.

This PR would implement a method, `SpeciesDefs::_extract_identifying_prefix`, which if called in `eg-web-common` method `SpeciesDefs::abbreviated_species_label` (as proposed in [eg-web-common PR 141](https://github.com/EnsemblGenomes/eg-web-common/pull/141)),  would address this issue effectively for all current Metazoan genomes, and any Metazoa Compara genomes following the existing naming conventions in the current Ensembl site.

Because the nature of this fix depends on the continuity of Metazoa Compara display name conventions in the current Ensembl Metazoa site, this PR has been marked as ready for review following the input of the relevant team.

The following screenshot shows how the Drosophila pangenome Cactus alignment would look following this change, and the related ticket contains a table of current Metazoa genomes, with their current abbreviated species labels and the new labels they would have under the proposed solution.

---
![dmel_pangenome_cactus_binomials](https://github.com/user-attachments/assets/9b4f369f-3eb4-4a6a-ae58-b717ed077d7f)
---

### Related JIRA Issues

- ENSCOMPARASW-8473
