### PR TITLE
Pass s1 param in create_gene_tree_links

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaOrthologs.pm
@@ -30,6 +30,7 @@ sub create_gene_tree_links {
   my $hub          = $self->hub;
   my $anc_node_ids = $params->{anc_node_ids};
   my $stable_id = $params->{stable_id};
+  my $s1 = $params->{s1};
   my $orthologue = $params->{orthologue};
   my $cdb = $params->{cdb};
 
@@ -54,6 +55,7 @@ sub create_gene_tree_links {
       type   => 'Gene',
       action => $url_part,
       g1     => $stable_id,
+      s1     => $s1,
       anc    => $anc_node_id,
       r      => undef
     });


### PR DESCRIPTION
In conjunction with [ensembl-webcode PR 1091](https://github.com/Ensembl/ensembl-webcode/pull/1091) and [eg-web-common PR 143](https://github.com/EnsemblGenomes/eg-web-common/pull/143), this PR would ensure that the `s1` parameter is passed to each gene-tree URL created by the Metazoa-specific implementation of `ComparaOrthologs::create_gene_tree_links`.
