### PR TITLE
Set explicit default clusterset_id config option

### DIFF
--- a/modules/EnsEMBL/Web/Object/Gene.pm
+++ b/modules/EnsEMBL/Web/Object/Gene.pm
@@ -1,0 +1,33 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2025] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package EnsEMBL::Web::Object::Gene;
+
+use strict;
+
+
+sub _resolve_clusterset_ids {
+  my ($self, $strain_tree) = @_;
+  # In Metazoa gene-tree views, the clusterset_id parameter is hard-coded
+  # to the consensus clusterset_id of the relevant gene-tree view.
+  return [$self->hub->param('clusterset_id'), undef];
+}
+
+
+1;

--- a/modules/EnsEMBL/Web/ViewConfig/Gene/DrosophilidaeTree.pm
+++ b/modules/EnsEMBL/Web/ViewConfig/Gene/DrosophilidaeTree.pm
@@ -34,4 +34,14 @@ sub init_cacheable {
   $self->set_default_options({'clusterset_id' => 'pangenome_drosophila'});
 }
 
+sub init_form_non_cacheable {
+  my $self = shift;
+
+  if (my $dropdown = $self->form->get_elements_by_name('clusterset_id')->[0]) {
+    $self->_replace_default_clusterset_id_option($dropdown, 'pangenome_drosophila');
+  }
+
+  return $self->form;
+}
+
 1;

--- a/modules/EnsEMBL/Web/ViewConfig/Gene/InsectsTree.pm
+++ b/modules/EnsEMBL/Web/ViewConfig/Gene/InsectsTree.pm
@@ -34,4 +34,14 @@ sub init_cacheable {
   $self->set_default_options({'clusterset_id' => 'insects'});
 }
 
+sub init_form_non_cacheable {
+  my $self = shift;
+
+  if (my $dropdown = $self->form->get_elements_by_name('clusterset_id')->[0]) {
+    $self->_replace_default_clusterset_id_option($dropdown, 'insects');
+  }
+
+  return $self->form;
+}
+
 1;

--- a/modules/EnsEMBL/Web/ViewConfig/Gene/ProtostomesTree.pm
+++ b/modules/EnsEMBL/Web/ViewConfig/Gene/ProtostomesTree.pm
@@ -34,4 +34,14 @@ sub init_cacheable {
   $self->set_default_options({'clusterset_id' => 'protostomes'});
 }
 
+sub init_form_non_cacheable {
+  my $self = shift;
+
+  if (my $dropdown = $self->form->get_elements_by_name('clusterset_id')->[0]) {
+    $self->_replace_default_clusterset_id_option($dropdown, 'protostomes');
+  }
+
+  return $self->form;
+}
+
 1;


### PR DESCRIPTION
In conjunction with [ensembl-webcode PR 1095](https://github.com/Ensembl/ensembl-webcode/pull/1095), this pull request would facilitate handling of gene tree configuration.

This PR would replace the default `clusterset_id` of Protostomes, Insects and Drosophilidae gene tree views with an explicit default `clusterset_id` (i.e. `protostomes`, `insects` and `pangenome_drosophila`, respectively).

It would also add method `EnsEMBL::Web::Object::Gene::_resolve_clusterset_ids` to ensure that priority is given to the `clusterset_id` parameter in Metazoa gene-tree views, in which the `clusterset_id` parameter is hard-coded to an appropriate default value.

Note that the changes in this PR do not in any way restrict the user's access to non-default gene trees, but simply update the "Model used for the tree reconstruction" dropdown to reflect more accurately the set of  currently accessible gene trees.

See related ticket ENSCOMPARASW-8521 for an example test case.