### PR TITLE
Tweak Ensembl provider URLs during config pack

### DIFF
--- a/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -21,7 +21,7 @@ use strict;
 use warnings;
 no warnings qw(uninitialized);
 
-use previous qw(munge_databases_multi);
+use previous qw(_munge_meta munge_databases_multi);
 
 sub munge_databases_multi {
   my $self = shift;
@@ -69,6 +69,23 @@ sub _configure_new_gene_trees {
         $self->db_tree->{$db_name}{'METAZOA_CLUSTERSETS'}{$sp} = [$clusterset_id];
       }
    }
+  }
+}
+
+sub _munge_meta {
+  my $self = shift;
+  $self->PREV::_munge_meta(@_);
+  my $full_tree = $self->full_tree;
+  foreach my $species (keys %{$full_tree}) {
+    foreach my $key ('ASSEMBLY_PROVIDER_URL', 'ANNOTATION_PROVIDER_URL') {
+      if (exists $full_tree->{$species}{$key}) {
+        if ($full_tree->{$species}{$key} eq 'www.metazoa.ensembl.org') {
+          $full_tree->{$species}{$key} = 'https://metazoa.ensembl.org';
+        } elsif ($full_tree->{$species}{$key} eq 'www.ensembl.org') {
+          $full_tree->{$species}{$key} = 'https://www.ensembl.org';
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
This PR would tweak Metazoa `ConfigPacker` code to make the following changes to provider URLs during the packing process:

- `www.metazoa.ensembl.org` would be replaced by `https://metazoa.ensembl.org`
- `www.ensembl.org` would be replaced by `https://www.ensembl.org`

This would circumvent an issue whereby provider URLs lacking a protocol are interpreted as relative to the current page, causing them to lead back to the current page.

With these changes, if the Metazoa `packed` files are regenerated before release, it would have the effect of fixing one or both provider URLs in the species pages of the following 29 genomes in Ensembl Metazoa.

- `Amblyteles_armatorius_gca933228735v1`: [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Amblyteles_armatorius_gca933228735v1/Info/Annotation/) vs [staging](https://staging-metazoa.ensembl.org/Amblyteles_armatorius_gca933228735v1/Info/Annotation/)
- `Ancistrocerus_nigricornis_gca916049575v1`: [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Ancistrocerus_nigricornis_gca916049575v1/Info/Annotation/) vs [staging](https://staging-metazoa.ensembl.org/Ancistrocerus_nigricornis_gca916049575v1/Info/Annotation/)
- `Anopheles_atroparvus_GCA_914969975.1`: [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Anopheles_atroparvus_GCA_914969975.1/Info/Annotation/) vs [staging](https://staging-metazoa.ensembl.org/Anopheles_atroparvus_GCA_914969975.1/Info/Annotation/)
- `Asterias_rubens_GCA_902459465.3`: [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Asterias_rubens_GCA_902459465.3/Info/Annotation/) vs [staging](https://staging-metazoa.ensembl.org/Asterias_rubens_GCA_902459465.3/Info/Annotation/)
- `Athalia_rosae_gca917208135v1`: [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Athalia_rosae_gca917208135v1/Info/Annotation/) vs [staging](https://staging-metazoa.ensembl.org/Athalia_rosae_gca917208135v1/Info/Annotation/)
- `Bemisia_tabaci_asiaii5`: [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Bemisia_tabaci_asiaii5/Info/Annotation/) vs [staging](https://staging-metazoa.ensembl.org/Bemisia_tabaci_asiaii5/Info/Annotation/)
- `Bemisia_tabaci_ssa1nig`: [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Bemisia_tabaci_ssa1nig/Info/Annotation/) vs [staging](https://staging-metazoa.ensembl.org/Bemisia_tabaci_ssa1nig/Info/Annotation/)
- `Bemisia_tabaci_ssa1ug`: [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Bemisia_tabaci_ssa1ug/Info/Annotation/) vs [staging](https://staging-metazoa.ensembl.org/Bemisia_tabaci_ssa1ug/Info/Annotation/)
- `Bemisia_tabaci_ssa2nig`: [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Bemisia_tabaci_ssa2nig/Info/Annotation/) vs [staging](https://staging-metazoa.ensembl.org/Bemisia_tabaci_ssa2nig/Info/Annotation/)
- `Bemisia_tabaci_ssa3nig`: [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Bemisia_tabaci_ssa3nig/Info/Annotation/) vs [staging](https://staging-metazoa.ensembl.org/Bemisia_tabaci_ssa3nig/Info/Annotation/)
- `Bemisia_tabaci_uganda1`: [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Bemisia_tabaci_uganda1/Info/Annotation/) vs [staging](https://staging-metazoa.ensembl.org/Bemisia_tabaci_uganda1/Info/Annotation/)
- `Bicyclus_anynana_gca947172395v1`: [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Bicyclus_anynana_gca947172395v1/Info/Annotation/) vs [staging](https://staging-metazoa.ensembl.org/Bicyclus_anynana_gca947172395v1/Info/Annotation/)
- `Bombus_terrestris_gca910591885v2`: [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Bombus_terrestris_gca910591885v2/Info/Annotation/) vs [staging](https://staging-metazoa.ensembl.org/Bombus_terrestris_gca910591885v2/Info/Annotation/)
- `Coremacera_marginata_gca914767935v1`: [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Coremacera_marginata_gca914767935v1/Info/Annotation/) vs [staging](https://staging-metazoa.ensembl.org/Coremacera_marginata_gca914767935v1/Info/Annotation/)
- `Danaus_plexippus_gca018135715v1`: [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Danaus_plexippus_gca018135715v1/Info/Annotation/) vs [staging](https://staging-metazoa.ensembl.org/Danaus_plexippus_gca018135715v1/Info/Annotation/)
- `Glyphotaelius_pellucidus_gca936435175v1`: [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Glyphotaelius_pellucidus_gca936435175v1/Info/Annotation/) vs [staging](https://staging-metazoa.ensembl.org/Glyphotaelius_pellucidus_gca936435175v1/Info/Annotation/)
- `Homarus_gammarus_gca958450375v1`: [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Homarus_gammarus_gca958450375v1/Info/Annotation/) vs [staging](https://staging-metazoa.ensembl.org/Homarus_gammarus_gca958450375v1/Info/Annotation/)
- `Ichneumon_xanthorius_gca917499995v1`: [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Ichneumon_xanthorius_gca917499995v1/Info/Annotation/) vs [staging](https://staging-metazoa.ensembl.org/Ichneumon_xanthorius_gca917499995v1/Info/Annotation/)
- `Limnephilus_lunatus_gca917563855v2`: [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Limnephilus_lunatus_gca917563855v2/Info/Annotation/) vs [staging](https://staging-metazoa.ensembl.org/Limnephilus_lunatus_gca917563855v2/Info/Annotation/)
- `Limnephilus_marmoratus_gca917880885v1`: [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Limnephilus_marmoratus_gca917880885v1/Info/Annotation/) vs [staging](https://staging-metazoa.ensembl.org/Limnephilus_marmoratus_gca917880885v1/Info/Annotation/)
- `Limnephilus_rhombicus_gca929108145v2`: [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Limnephilus_rhombicus_gca929108145v2/Info/Annotation/) vs [staging](https://staging-metazoa.ensembl.org/Limnephilus_rhombicus_gca929108145v2/Info/Annotation/)
- `Limnoperna_fortunei_gca944474755v1`: [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Limnoperna_fortunei_gca944474755v1/Info/Annotation/) vs [staging](https://staging-metazoa.ensembl.org/Limnoperna_fortunei_gca944474755v1/Info/Annotation/)
- `Lineus_longissimus_gca910592395v2`: [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Lineus_longissimus_gca910592395v2/Info/Annotation/) vs [staging](https://staging-metazoa.ensembl.org/Lineus_longissimus_gca910592395v2/Info/Annotation/)
- `Machimus_atricapillus_gca933228815v1`: [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Machimus_atricapillus_gca933228815v1/Info/Annotation/) vs [staging](https://staging-metazoa.ensembl.org/Machimus_atricapillus_gca933228815v1/Info/Annotation/)
- `Melitaea_cinxia_gca905220565v1`: [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Melitaea_cinxia_gca905220565v1/Info/Annotation/) vs [staging](https://staging-metazoa.ensembl.org/Melitaea_cinxia_gca905220565v1/Info/Annotation/)
- `Myopa_tessellatipennis_gca943737955v2`: [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Myopa_tessellatipennis_gca943737955v2/Info/Annotation/) vs [staging](https://staging-metazoa.ensembl.org/Myopa_tessellatipennis_gca943737955v2/Info/Annotation/)
- `Patella_pellucida_gca917208275v1`: [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Patella_pellucida_gca917208275v1/Info/Annotation/) vs [staging](https://staging-metazoa.ensembl.org/Patella_pellucida_gca917208275v1/Info/Annotation/)
- `Patella_vulgata_gca932274485v1`: [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Patella_vulgata_gca932274485v1/Info/Annotation/) vs [staging](https://staging-metazoa.ensembl.org/Patella_vulgata_gca932274485v1/Info/Annotation/)
- `Phlebotomus_perniciosus_GCA_918844115.2`: [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Phlebotomus_perniciosus_GCA_918844115.2/Info/Annotation/) vs [staging](https://staging-metazoa.ensembl.org/Phlebotomus_perniciosus_GCA_918844115.2/Info/Annotation/)